### PR TITLE
Adds support for SPDX Format from the SBOM formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Safety can output the scan results in a variety of formats and outputs. This inc
 ```--output json``` will output JSON for further processing and analysis.
 ```--output text``` can be used to save the scan to file to later auditing.
 ```--output bare``` simply prints out the packages that have known vulnerabilities
+```--output spdx``` will output SPDX format
 
 ### Exit codes
 

--- a/safety/formatter.py
+++ b/safety/formatter.py
@@ -52,6 +52,7 @@ class SafetyFormatter(FormatterAPI):
         from safety.formatters.json import JsonReport
         from safety.formatters.bare import BareReport
         from safety.formatters.html import HTMLReport
+        from safety.formatters.spdx import SPDXReport
 
         self.format = ScreenReport(**kwargs)
 
@@ -63,3 +64,5 @@ class SafetyFormatter(FormatterAPI):
             self.format = BareReport(**kwargs)
         elif output == 'text':
             self.format = TextReport(**kwargs)
+        elif output == 'spdx':
+            self.format = SPDXReport(**kwargs)

--- a/safety/formatters/spdx.py
+++ b/safety/formatters/spdx.py
@@ -1,0 +1,32 @@
+import logging
+
+from safety.formatter import FormatterAPI
+from safety.formatters.json import build_json_report
+from safety.output_utils import create_spdx_document
+
+
+LOG = logging.getLogger(__name__)
+
+
+class SPDXReport(FormatterAPI):
+    """SPDX report"""
+
+    VERSIONS = ("2.2", "2.3")
+
+    def __init__(self, version="2.3", **kwargs):
+        super().__init__(**kwargs)
+        self.version: str = version if version in self.VERSIONS else "2.3"
+
+    def render_vulnerabilities(self, announcements, vulnerabilities, remediations, full, packages, fixes=()):
+        LOG.debug(
+            f'SPDX Report Output, Rendering {len(vulnerabilities)} vulnerabilities, {len(remediations)} package '
+            f'remediations with full_report: {full}')
+        report = build_json_report(announcements, vulnerabilities, remediations, packages)
+        doc = create_spdx_document(report, self.version)
+        return doc
+
+    def render_licenses(self, announcements, licenses):
+        pass
+
+    def render_announcements(self, announcements):
+        pass

--- a/safety/util.py
+++ b/safety/util.py
@@ -424,6 +424,11 @@ def bare_alias(ctx, param, value):
         os.environ['SAFETY_OUTPUT'] = 'bare'
         return value
 
+def spdx_alias(ctx, param, value):
+    if value:
+        os.environ['SAFETY_OUTPUT'] = 'spdx'
+        return value
+
 
 def get_terminal_size():
     from shutil import get_terminal_size as t_size

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ python_requires = >=3.6
 [options.extras_require]
 github = pygithub>=1.43.3
 gitlab = python-gitlab>=1.3.0
+spdx = spdx-tools>=0.7.1
 
 [flake8]
 exclude = docs


### PR DESCRIPTION
Adds support for SPDX formats

**Requirement**
- Installation of the safety along with spdx python library
```pip install safety[spdx]```

To generate a spdx file with the details about scanned packages
```safety check --save-spdx-document .```

This will create a file with name ```safety-report-spdx.json``` in the safety directory

Todo:
- Add tests
